### PR TITLE
Add support for UTF-8 filenames

### DIFF
--- a/link-bin-outputs.py
+++ b/link-bin-outputs.py
@@ -56,6 +56,9 @@ if __name__ == '__main__':
                 get_bin_attr_files(package_json),
                 get_directories_bin_attr_files(args.lib_out, package_json))):
 
+        fin = fin.encode("utf-8");
+        fout = fout.encode("utf-8");
+
         os.symlink(fin, fout)
         os.chmod(fout, 0o755)
 


### PR DESCRIPTION
Without this patch, building a project that requires Ember fails due to a file called `🐹`.
This patch fixes builds for projects with files containing non-ASCII characters.
```
unpacking source archive /nix/store/ymyv1w0pqzxv89mhjd6cibnjrp7bcz2m-pnpm2nix-source-ember-cli
source root is .
patching sources
configuring
building
installing
Traceback (most recent call last):
  File "/nix/store/7rn33xc994mw74xav5pwffcsdfz6nczm-link-bin-outputs.py", line 59, in <module>
    os.symlink(fin, fout)
UnicodeEncodeError: 'ascii' codec can't encode character u'\U0001f439' in position 65: ordinal not in range(128)
```