### PR TITLE
Newer lockfile support, dirty tar support, (partial?) Git support

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -132,6 +132,17 @@ in {
     in {
       name = "pnpm2nix-source-${name}";
       inherit src;
+
+      # Make dirty tars work
+      TAR_OPTIONS = "--delay-directory-restore";
+      # We're still making them writable, but we need to run something else first
+      dontMakeSourcesWritable = true;
+      # Make directories have +x and everything writable
+      postUnpack = ''
+        find . -type d -exec chmod u+x {} \;
+        chmod -R u+w -- "$sourceRoot"
+      '';
+
       dontBuild = true;
       configurePhase = ":";
       fixupPhase = ":";

--- a/default.nix
+++ b/default.nix
@@ -139,7 +139,7 @@ in {
       dontMakeSourcesWritable = true;
       # Make directories have +x and everything writable
       postUnpack = ''
-        find . -type d -exec chmod u+x {} \;
+        find "$sourceRoot" -type d -exec chmod u+x {} \;
         chmod -R u+w -- "$sourceRoot"
       '';
 

--- a/default.nix
+++ b/default.nix
@@ -163,7 +163,10 @@ in {
             then pkgInfo.resolution.tarball
             else "${registry}${pkgInfo.pname}/-/${tarball}";
             "${shaType}" = shaSum;
-        }) else if allowImpure then fetchTarball {
+        }) else if (lib.hasAttr "commit" pkgInfo.resolution) then builtins.fetchGit {
+          url = pkgInfo.resolution.repo;
+          rev = pkgInfo.resolution.commit;
+        } else if allowImpure then fetchTarball {
           # Note: Resolved tarballs(github revs for example)
           # does not yet have checksums
           # https://github.com/pnpm/pnpm/issues/1035
@@ -195,7 +198,7 @@ in {
       };
 
   in
-    assert pnpmlock.lockfileVersion == 5;
+    assert (pnpmlock.lockfileVersion == 5 || pnpmlock.lockfileVersion == 5.1);
   (mkPnpmDerivation {
     deps = (builtins.map
       (attrName: packages."${attrName}")

--- a/semver.nix
+++ b/semver.nix
@@ -1,6 +1,4 @@
-{ pkgs ? import <nixpkgs> {}
-, lib ? pkgs.lib
-}:
+{ pkgs ? import <nixpkgs> {}, lib ? pkgs.lib }:
 
 let
   inherit (builtins) elemAt match;
@@ -8,24 +6,31 @@ let
   # Replace a list entry at defined index with set value
   ireplace = idx: value: list: let
     inherit (builtins) genList length;
-  in genList (i: if i == idx then value else (elemAt list i)) (length list);
+  in
+  genList (i: if i == idx then value else (elemAt list i)) (length list);
 
   operators = let
-    matchWildCard = s: match "(.*)(\.[x\*])" s;
-    mkComparison = ret: version: v: builtins.compareVersions version v == ret;
+    mkComparison = ret: version: v:
+    let
+      x = 1;
+    in
+    builtins.compareVersions version v == ret;
+
     mkIdxComparison = idx: version: v: let
       ver = builtins.splitVersion v;
       minor = builtins.toString (lib.toInt (elemAt ver idx) + 1);
       upper = builtins.concatStringsSep "." (ireplace idx minor ver);
-    in operators.">=" version v && operators."<" version upper;
+    in
+    operators.">=" version v && operators."<" version upper;
+
     dropWildcardPrecision = f: version: constraint: let
-      m = matchWildCard constraint;
-      hasWildcard = m != null;
-      c = if hasWildcard then (elemAt m 0) else constraint;
-      v =
-        if hasWildcard then (builtins.substring 0 (builtins.stringLength c) version)
-        else version;
-    in f v c;
+      # TODO: some stricter trailing-wildcard matching
+      wildcardMatch = match "(.*?)([0-9]\\.[0-9]\\.[0-9]|[0-9]\\.[0-9]|[0-9])?([.x*]*)" constraint;
+      matchPart = (elemAt wildcardMatch 1);
+      shortConstraint = if matchPart != null then matchPart else "";
+      shortVersion = builtins.substring 0 (builtins.stringLength shortConstraint) version;
+    in
+    f shortVersion shortConstraint;
   in {
     # Prefix operators
     "==" = dropWildcardPrecision (mkComparison 0);
@@ -37,37 +42,67 @@ let
     # Semver specific operators
     "~" = mkIdxComparison 1;  #
     "^" = mkIdxComparison 0;
-    # Infix operators
-    "-" = version: v: operators.">=" version v.vl && operators."<=" version v.vu;
   };
 
   re = {
-    operators = "([=><!~\^]+)";
-    version = "([0-9\.\*x]+)";
+    operators = "([=><!~^]+)";
+    version = "([0-9.*x]+|[0-9.*x]+-[a-z0-9]+)";
   };
 
   parseConstraint = constraintStr: let
     # The common prefix operators
     mPre = match "${re.operators} *${re.version}" constraintStr;
+    # There is an upper bound to the operator (this implementation is a bit hacky)
+    mUpperBound = match "${re.operators} *${re.version} *< *${re.version}" constraintStr; 
     # There is also an infix operator to match ranges
-    mIn = match "${re.version} *(-) *${re.version}" constraintStr;
+    mIn = match "${re.version} - *${re.version}" constraintStr;
+    # There is no operators
+    mNone = match "${re.version}" constraintStr;
   in (
     if mPre != null then {
-      op = elemAt mPre 0;
+      ops.t = elemAt mPre 0;
       v = elemAt mPre 1;
     }
     # Infix operators are range matches
     else if mIn != null then {
-      op = elemAt mIn 1;
+      ops = {
+        t = "-";
+        l = ">=";
+        u = "<=";
+      };
       v = {
         vl = (elemAt mIn 0);
-        vu = (elemAt mIn 2);
+        vu = (elemAt mIn 1);
       };
+    }
+    else if mUpperBound != null then {
+      ops = {
+        t = "-";
+        l = (elemAt mUpperBound 0);
+        u = "<";
+      };
+      v = {
+        vl = (elemAt mUpperBound 1);
+        vu = (elemAt mUpperBound 2);
+      };
+    }
+    else if mNone != null then {
+      ops.t = "==";
+      v = elemAt mNone 0;
     }
     else throw "Constraint \"${constraintStr}\" could not be parsed");
 
-  satisfies = version: constraint: let
-    inherit (parseConstraint constraint) op v;
-  in operators."${op}" version v;
+  satisfiesSingle = version: constraint:
+  let
+    inherit (parseConstraint constraint) ops v;
+  in
+  if ops.t == "-" then
+    (operators."${ops.l}" version v.vl && operators."${ops.u}" version v.vu)
+  else
+    operators."${ops.t}" version v;
+
+  satisfies = version: constraint:
+    # TODO: use a regex for the split
+    builtins.length (builtins.filter (c: satisfiesSingle version c) (lib.splitString " || " constraint)) > 0;
 
 in { inherit satisfies; }


### PR DESCRIPTION
Here is a set of fixes I composed to make `pnpm2nix` work properly on all my projects
- Semver `1.0.0 || 3.0.0` Allow matching either of separate conditions
- Semver `>=1.0.0 < 1.3.0` Allow "or" upper bound conditions on versions (I only added support for `<` upper bound, maybe more are in-spec?)
- Semver `1.x.x` and `*` Fix matching of certain types of wildcards
- Deal with tar file dependencies that have incorrect permissions
- Allow lockfile version `5.1`
- Support dependencies that have `pkgInfo.resolution` using `builtins.fetchGit` (which allows a commit hash in place of a checksum)

This is a WIP, the results haven't been tested. Only that it builds, I'll update this if required in the future